### PR TITLE
small change to make private msgs display more accurately, starting w…

### DIFF
--- a/chatroom/src/server/ServerThread.java
+++ b/chatroom/src/server/ServerThread.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
+import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -14,6 +15,7 @@ public class ServerThread extends Thread {
     private boolean isRunning = false;
     private Room currentRoom;// what room we are in, should be lobby by default
     private String clientName;
+    private ArrayList<String> muteList = new ArrayList<String>(); //keeps track of names of users this client has muted
     private final static Logger log = Logger.getLogger(ServerThread.class.getName());
 
     public String getClientName() {
@@ -31,6 +33,18 @@ public class ServerThread extends Thread {
 	else {
 	    log.log(Level.INFO, "Passed in room was null, this shouldn't happen");
 	}
+    }
+    
+    public ArrayList<String> getMuteList() {
+    	return muteList;
+    }
+    
+    public void muteUser(String username) {
+    	muteList.add(username);
+    }
+    
+    public void unmuteUser(String username) {
+    	muteList.remove(username);
     }
 
     public ServerThread(Socket myClient, Room room) throws IOException {


### PR DESCRIPTION
…ork on mute/unmute
![image](https://user-images.githubusercontent.com/70596942/102320243-05a8a400-3f4a-11eb-8138-de6edd84e0c8.png)
There is a lot going on in the screenshot, but muting seems to work for the most part (not for private messaging yet though, which is why it’s marked orange). In the screenshot, testman mutes lily (we can see the commands used in the leftmost console, underlined with red, since it doesn’t show in the chat). When she sends the “hi” message, only bob and her get it since testman muted lily. He unmutes her after and is able to receive her messages again. The bottom consoles also show that testman doesn’t receive the data from lily when he mutes her. 
