### PR TITLE
adding notifications for every time someone goes from muted->unmuted …

### DIFF
--- a/chatroom/src/client/ClientUI.java
+++ b/chatroom/src/client/ClientUI.java
@@ -301,6 +301,10 @@ public class ClientUI extends JFrame implements Event {
 		} else if (name.equals("Roll result")) {
 			entry.setBackground(Color.LIGHT_GRAY);
 			displayStr = "Rolling a die... result is <b><u>" + msg + "</b></u>";
+		} else if(name.equals("Muted")) {
+			displayStr = "<i><u>" + msg + "</u> muted you!</i>";
+		} else if(name.equals("Unmuted")) {
+			displayStr = "<i><u>" + msg + "</u> unmuted you!</i>";
 		}
 		else {
 			displayStr = name + ":" + msg;	

--- a/chatroom/src/server/Room.java
+++ b/chatroom/src/server/Room.java
@@ -139,14 +139,24 @@ public class Room implements AutoCloseable {
 			sendFlip();
 			wasCommand = true;
 			break;
+		//check if the username is already in the mute list or not
 		case MUTE:
 			targetUserName = comm2[1];
-			client.muteUser(targetUserName);
+
+			if(!client.getMuteList().contains(targetUserName)) {
+				client.muteUser(targetUserName);
+				sendMuteMessage(client.getClientName(), targetUserName);
+			}
+			
 			wasCommand = true;
 			break;
 		case UNMUTE:
 			targetUserName = comm2[1];
-			client.unmuteUser(targetUserName);
+			
+			if(client.getMuteList().contains(targetUserName)) {
+				client.unmuteUser(targetUserName);
+				sendUnmuteMessage(client.getClientName(), targetUserName);
+			}
 			wasCommand = true;
 			break;
 		}
@@ -263,6 +273,36 @@ public class Room implements AutoCloseable {
     	return true;
     }
    
+    //muter = the person muting the muted
+    protected void sendMuteMessage(String muter, String muted) {
+    	Iterator<ServerThread> iter = clients.iterator();
+    	while (iter.hasNext()) {
+    	    ServerThread c = iter.next();
+    	    if (c.getClientName().equals(muted)) {
+    	    	 boolean messageSent = c.send("Muted", muter);
+    	    	 if (!messageSent) {
+    	    		iter.remove();
+    	    		log.log(Level.INFO, "Removed client " + c.getId());
+    	    	 }
+    	    }
+    	}
+    }
+    
+    //repetitive, so maybe merge into one method
+    protected void sendUnmuteMessage(String unmuter, String unmuted) {
+    	Iterator<ServerThread> iter = clients.iterator();
+    	while (iter.hasNext()) {
+    	    ServerThread c = iter.next();
+    	    if (c.getClientName().equals(unmuted)) {
+    	    	 boolean messageSent = c.send("Unmuted", unmuter);
+    	    	 if (!messageSent) {
+    	    		iter.remove();
+    	    		log.log(Level.INFO, "Removed client " + c.getId());
+    	    	 }
+    	    }
+    	}
+    }
+    
     //could combine sendFlip and sendRoll into one function...?
     protected void sendFlip() {
     	String result = "";


### PR DESCRIPTION
…and vice versa

![image](https://user-images.githubusercontent.com/70596942/102418996-df781800-3fcc-11eb-80f8-0709ad2e96fe.png)
In the above screenshot, we can see that testman calls /mute bob twice (which works) but bob (the leftmost window) only gets the notification once. Same thing happens when testman does /unmute bob twice (also works). We can see these client messages sent in the bottom console. These mute/unmute notification messages are only sent if a user goes from muted to unmuted or unmuted to muted.
