### PR TITLE
added user list updating functionality based on various statuses

### DIFF
--- a/chatroom/src/client/ClientUI.java
+++ b/chatroom/src/client/ClientUI.java
@@ -179,6 +179,7 @@ public class ClientUI extends JFrame implements Event {
 	u.setPreferredSize(p);
 	u.setMinimumSize(p);
 	u.setMaximumSize(p);
+	u.setBackgroundColor(Color.decode("#ebeef0"));
 	userPanel.add(u);
 	users.add(u);
 	pack();
@@ -189,6 +190,37 @@ public class ClientUI extends JFrame implements Event {
 	client.removeAll();
 	userPanel.revalidate();
 	userPanel.repaint();
+    }
+    
+    //m indicates whether to unmute or mute
+    void updateUserList(String m, String username) {
+    	if(m.equals("You muted")) {
+    		Iterator<User> iter = users.iterator();
+    		while (iter.hasNext()) {
+    		    User u = iter.next();
+    		    if (u.getName().equals(username)) {
+    		    	u.setBackgroundColor(Color.GRAY);
+    		    }
+    		}
+    	} else if(m.equals("You unmuted")) {
+    		Iterator<User> iter = users.iterator();
+    		while (iter.hasNext()) {
+    		    User u = iter.next();
+    		    if (u.getName().equals(username)) {
+    		    	u.setBackgroundColor(Color.decode("#ebeef0"));
+    		    }
+    		}
+    	} else {
+    		Iterator<User> iter = users.iterator();
+    		while (iter.hasNext()) {
+    			User u = iter.next();
+    		    if (u.getName().equals(m)) {
+    		    	u.setBackgroundColor(Color.CYAN);
+    		    } else {
+    		    	u.setBackgroundColor(Color.decode("#ebeef0"));
+    		    }
+    		}
+    	}
     }
 
     /***
@@ -375,7 +407,15 @@ public class ClientUI extends JFrame implements Event {
     @Override
     public void onMessageReceive(String clientName, String message) {
 	log.log(Level.INFO, String.format("%s: %s", clientName, message));
-	self.addMessage(String.format("%s: %s", clientName, message));
+	if(clientName.equals("You muted") || clientName.equals("You unmuted")) {
+		updateUserList(clientName, message);
+	} else {
+		self.addMessage(String.format("%s: %s", clientName, message));
+		//terrible logic
+		if(!clientName.equals("Flip result") && !clientName.equals("Roll result") && !clientName.equals("Muted") && !clientName.equals("Unmuted")) {
+			updateUserList(clientName, message);
+		}
+	}
     }
 
     @Override

--- a/chatroom/src/client/User.java
+++ b/chatroom/src/client/User.java
@@ -1,6 +1,7 @@
 package client;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -19,5 +20,9 @@ public class User extends JPanel {
 
     public String getName() {
 	return name;
+    }
+    
+    public void setBackgroundColor(Color color) {
+    	nameField.setBackground(color);
     }
 }

--- a/chatroom/src/server/Room.java
+++ b/chatroom/src/server/Room.java
@@ -284,6 +284,12 @@ public class Room implements AutoCloseable {
     	    		iter.remove();
     	    		log.log(Level.INFO, "Removed client " + c.getId());
     	    	 }
+    	    } else if (c.getClientName().equals(muter)) {
+    	    	boolean messageSent = c.send("You muted", muted);
+    	    	if (!messageSent) {
+	   	    		iter.remove();
+	   	    		log.log(Level.INFO, "Removed client " + c.getId());
+    	    	}
     	    }
     	}
     }
@@ -299,6 +305,12 @@ public class Room implements AutoCloseable {
     	    		iter.remove();
     	    		log.log(Level.INFO, "Removed client " + c.getId());
     	    	 }
+    	    } else if (c.getClientName().equals(unmuter)) {
+    	    	boolean messageSent = c.send("You unmuted", unmuted);
+    	    	if (!messageSent) {
+	   	    		iter.remove();
+	   	    		log.log(Level.INFO, "Removed client " + c.getId());
+    	    	}
     	    }
     	}
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70596942/102450027-94c5c280-4003-11eb-9395-7320ec8bd085.png)
(user list changes based on whether a user mutes/unmutes another user or when a user broadcasts a message to other clients)
I implemented both muted users appearing grayed out and highlighting the last person to send a message here. As seen above, the user list to the right gets updated when a user mutes/unmutes someone or when someone sends a message that is broadcasted to other clients. The user lily mutes bob, causing his name to be grayed out only for her window. He then sends a message, and bob and testman’s “bob” name panel light up since the last message they received was from him, but for lily (who muted bob), her last message received was from testman, who is highlighted in her user list. It’s not shown, but if lily does /unmute bob, the color goes back to the normal color. The list updates accordingly.
