### PR TITLE
option to export current session's chat log

### DIFF
--- a/chatroom/src/server/Room.java
+++ b/chatroom/src/server/Room.java
@@ -21,6 +21,7 @@ public class Room implements AutoCloseable {
     private final static String FLIP = "flip";
     private final static String MUTE = "mute";
     private final static String UNMUTE = "unmute";
+    private final static String EXPORT_CHAT_LOG = "export";
     
     Random rand = new Random();
 
@@ -157,6 +158,10 @@ public class Room implements AutoCloseable {
 				client.unmuteUser(targetUserName);
 				sendUnmuteMessage(client.getClientName(), targetUserName);
 			}
+			wasCommand = true;
+			break;
+		case EXPORT_CHAT_LOG:
+			client.exportChatLog();
 			wasCommand = true;
 			break;
 		}

--- a/chatroom/src/server/ServerThread.java
+++ b/chatroom/src/server/ServerThread.java
@@ -1,10 +1,12 @@
 package server;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -17,6 +19,8 @@ public class ServerThread extends Thread {
     private String clientName;
     private ArrayList<String> muteList = new ArrayList<String>(); //keeps track of names of users this client has muted
     private final static Logger log = Logger.getLogger(ServerThread.class.getName());
+    private String chatLogFile;
+    private ArrayList<String> chatLog = new ArrayList<String>(); //keeps track of a log of messages received by client
 
     public String getClientName() {
 	return clientName;
@@ -45,6 +49,25 @@ public class ServerThread extends Thread {
     
     public void unmuteUser(String username) {
     	muteList.remove(username);
+    }
+    
+    public void exportChatLog() {
+    	chatLogFile = clientName + "_exported_chat_log.txt";
+    	try (FileWriter fw = new FileWriter(chatLogFile, false);) {
+    		Iterator<String> iter = chatLog.iterator();
+    		while(iter.hasNext()) {
+    			fw.write("\n"+iter.next());
+    		}
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+    }
+    
+    //use this to add message to array keeping track of messages received by client for exporting the chat log
+    //dont know where to call it
+    private void addMessageToChatLog(String m) {
+    	chatLog.add(m);
     }
 
     public ServerThread(Socket myClient, Room room) throws IOException {
@@ -88,6 +111,7 @@ public class ServerThread extends Thread {
 	payload.setPayloadType(PayloadType.MESSAGE);
 	payload.setClientName(clientName);
 	payload.setMessage(message);
+	addMessageToChatLog(clientName + ": " + message); //not exactly working right, not the right format all the time
 
 	return sendPayload(payload);
     }

--- a/chatroom/src/server/ServerThread.java
+++ b/chatroom/src/server/ServerThread.java
@@ -111,7 +111,7 @@ public class ServerThread extends Thread {
 	payload.setPayloadType(PayloadType.MESSAGE);
 	payload.setClientName(clientName);
 	payload.setMessage(message);
-	addMessageToChatLog(clientName + ": " + message); //not exactly working right, not the right format all the time
+	addMessageToChatLog(clientName + ": " + message); //not exactly working right, not the right format all the time - and doesn't get everything in the log
 
 	return sendPayload(payload);
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70596942/102557283-c3da4380-4098-11eb-82c6-b8fa7e4efb8e.png)
At the left is ClientUI windows (test is on top, bob is on the bottom), the middle has the console output of the server (which shows the messages sent), and the right has the created file for the chat log in the workspace and the actual .txt file itself. test called /export, which created the file test_exported_chat_log.txt. (the first part of the file name, in this case “test”, is the user’s name). It mostly works, the chat log file that was exported is their current session’s chat (the file gets wiped and rewritten/written over if the same user comes back and starts a new session), the formatting is just off (the mute, flip, and roll messages are not formatted correctly in the .txt file).
