### PR TITLE
attempt at implementing persistent mute lists

### DIFF
--- a/chatroom/src/server/ServerThread.java
+++ b/chatroom/src/server/ServerThread.java
@@ -21,6 +21,7 @@ public class ServerThread extends Thread {
     private final static Logger log = Logger.getLogger(ServerThread.class.getName());
     private String chatLogFile;
     private ArrayList<String> chatLog = new ArrayList<String>(); //keeps track of a log of messages received by client
+    private String muteLogFile;
 
     public String getClientName() {
 	return clientName;
@@ -45,10 +46,12 @@ public class ServerThread extends Thread {
     
     public void muteUser(String username) {
     	muteList.add(username);
+    	updateMuteList("mute", username);
     }
     
     public void unmuteUser(String username) {
     	muteList.remove(username);
+    	updateMuteList("unmute", username);
     }
     
     public void exportChatLog() {
@@ -69,10 +72,27 @@ public class ServerThread extends Thread {
     private void addMessageToChatLog(String m) {
     	chatLog.add(m);
     }
+    
+    private void updateMuteList(String option, String username) {
+    	muteLogFile = clientName + "_mute_list.txt";
+    	if(option.equals("mute")) {
+    		try (FileWriter fw = new FileWriter(muteLogFile, true);) {
+    			fw.write("\n"+username);
+    		} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+    	} else if(option.equals("unmute")) {
+    		//???
+    		//not sure how to remove user from file based on username
+    	}
+    }
+    
 
     public ServerThread(Socket myClient, Room room) throws IOException {
 	this.client = myClient;
 	this.currentRoom = room;
+	//update this.muteList based on iterating through muteLogFile?
 	out = new ObjectOutputStream(client.getOutputStream());
 	in = new ObjectInputStream(client.getInputStream());
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70596942/102559250-6268a380-409d-11eb-841e-dffaba74d673.png)
Doesn’t really work as intended, but it’s kinda getting there? When test mutes bob, bob is added to a file that keeps the list of muted users by the client. However I didn’t figure out how to remove a user from the mute list file if they are unmuted, so there’s two copies of bob in the mute list because he got muted twice. The intention was to remove his name after every time he gets unmuted, but I wasn’t sure how to do that. Also there’s set up for mute lists to be persistent, but it doesn’t actually work right now, as I wasn’t able to code in iterating through the mute list file and adding that to the mute list array made within the code when the client connects to the server (because I think in this current state it would just break more).
